### PR TITLE
[CEN-889] Set resources on Container DEV

### DIFF
--- a/manifests/pagoPa/deployment-dev.yml
+++ b/manifests/pagoPa/deployment-dev.yml
@@ -17,6 +17,13 @@ spec:
           image: cstardacr.azurecr.io/bpdmscitizen
           ports:
             - containerPort: 8080
+          resources:
+            limits:
+              cpu: "1"
+              memory: "2000Mi"
+            requests:
+              cpu: "0.5"
+              memory: "700Mi"
           envFrom:
             - secretRef:
                 name: postgres-credentials
@@ -81,6 +88,13 @@ spec:
           image: cstardacr.azurecr.io/bpdmscitizen
           ports:
             - containerPort: 8080
+          resources:
+            limits:
+              cpu: "1"
+              memory: "2000Mi"
+            requests:
+              cpu: "0.5"
+              memory: "500Mi"
           env:
             - name: CITIZEN_DB_HOST
               valueFrom:


### PR DESCRIPTION
## Description
This PR proposes to add `resources` - `limit` and `requests` - in container definition of dev deployment.

## Motivation
The proposed changes are required to support Horizontal Pod Autoscaling, since - as reported in doc - 

_Please note that if some of the Pod's containers do not have the relevant resource request set, CPU utilization for the Pod will not be defined and the autoscaler will not take any action for that metric. See the algorithm details section below for more information about how the autoscaling algorithm works._

REF:
https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/