### PR TITLE
[CEN-889] Align Resource Limit in DEV Deployment Manifest

### DIFF
--- a/manifests/pagoPa/deployment-dev.yml
+++ b/manifests/pagoPa/deployment-dev.yml
@@ -19,11 +19,11 @@ spec:
             - containerPort: 8080
           resources:
             limits:
-              cpu: "1"
-              memory: "2000Mi"
+              cpu: 800m
+              memory: 4Gi
             requests:
-              cpu: "0.5"
-              memory: "700Mi"
+              cpu: 50m
+              memory: 256Mi
           envFrom:
             - secretRef:
                 name: postgres-credentials


### PR DESCRIPTION
## Description
In Deployment manifest it isn't reported resource limits and requests, which are essential to set autoscaling.